### PR TITLE
fix-Validate 500-char limit on Description & Aim/Cause with clear UX

### DIFF
--- a/client-app/src/Components/AddProgramPage.tsx
+++ b/client-app/src/Components/AddProgramPage.tsx
@@ -5,178 +5,188 @@ import '../css/AddProgramPage.css';
 import axios from 'axios';
 
 interface ProgramData {
-    name: string;
-    description: string;
-    startDate: string;
-    aimAndCause: string;
+  name: string;
+  description: string;
+  startDate: string;
+  aimAndCause: string;
 }
 
+const MAX_TEXT = 500;
+const isTooLong = (s: string) => s.trim().length > MAX_TEXT;
+const isEmpty = (s: string) => s.trim().length === 0;
+const isFormValid = (d: ProgramData) =>
+  !isEmpty(d.name) &&
+  !isEmpty(d.startDate) &&
+  !isEmpty(d.description) &&
+  !isEmpty(d.aimAndCause) &&
+  !isTooLong(d.description) &&
+  !isTooLong(d.aimAndCause);
+
 const AddProgramPage = () => {
-    const [formData, setFormData] = useState<ProgramData>({
-        name: '',
-        description: '',
-        startDate: '',
-        aimAndCause: '',
+  const [formData, setFormData] = useState<ProgramData>({
+    name: '',
+    description: '',
+    startDate: '',
+    aimAndCause: '',
+  });
+
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value,
     });
+  };
 
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
-    const [isLoading, setIsLoading] = useState(false);
-    const navigate = useNavigate();
+  const handleSave = async () => {
+    if (!isFormValid(formData)) return;
+    setIsLoading(true);
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_API_BASE_URL}program`,
+        formData,
+        {
+          headers: {
+            Authorization: localStorage.getItem('token'),
+          },
+        },
+      );
 
-    const handleChange = (
-        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    ) => {
-        const { name, value } = e.target;
-        setFormData({
-            ...formData,
-            [name]: value,
-        });
-    };
+      if (response.status === 201) {
+        setSuccess('Program created successfully!');
+        setError(null);
+        setTimeout(() => {
+          navigate('/programs');
+        }, 1200);
+      } else {
+        setError('Failed to create program.');
+        setSuccess(null);
+      }
+    } catch (error: unknown) {
+      const message =
+        (error as any).response?.data?.message ||
+        'Error creating program';
+      setError(message);
+      setSuccess(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-    const handleSave = async () => {
-        setIsLoading(true);
-        try {
-            const response = await axios.post(
-                `${process.env.REACT_APP_BACKEND_API_BASE_URL}program`,
-                formData,
-                {
-                    headers: {
-                        Authorization: localStorage.getItem('token'),
-                    },
-                },
-            );
+  const handleClear = () => {
+    setFormData({
+      name: '',
+      description: '',
+      startDate: '',
+      aimAndCause: '',
+    });
+    setError(null);
+    setSuccess(null);
+  };
 
-            if (response.status === 201) {
-                setSuccess('Program created successfully!');
-                setError(null);
-
-                setFormData({
-                    name: '',
-                    description: '',
-                    startDate: '',
-                    aimAndCause: '',
-                });
-
-                setTimeout(() => {
-                    navigate('/programs');
-                }, 2000);
-            } else {
-                setError('Failed to create program.');
-                setSuccess(null);
-            }
-        } catch (error: unknown) {
-            const message =
-                (error as any).response?.data?.message ||
-                'Error creating program';
-            setError(message);
-            setSuccess(null);
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    const handleClear = () => {
-        setIsLoading(true);
-        setFormData({
-            name: '',
-            description: '',
-            startDate: '',
-            aimAndCause: '',
-        });
-        setIsLoading(false);
-    };
-
-    return (
-        <div className="container">
-            <form
-                className="form"
-                onSubmit={e => {
-                    e.preventDefault();
-                    handleSave();
-                }}
-            >
-                <h1 className="heading">Add Program</h1>
-                <div className="form-group">
-                    <label className="label">
-                        Name <span className="required">*</span>
-                    </label>
-                    <input
-                        className="input"
-                        type="text"
-                        name="name"
-                        value={formData.name}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                <div className="form-group">
-                    <label className="label">
-                        Description <span className="required">*</span>
-                    </label>
-                    <textarea
-                        className="textarea"
-                        name="description"
-                        value={formData.description}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                <div className="form-group">
-                    <label className="label">
-                        Start Date <span className="required">*</span>
-                    </label>
-                    <input
-                        className="input"
-                        type="date"
-                        name="startDate"
-                        value={formData.startDate}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                <div className="form-group">
-                    <label className="label">
-                        Aim and Cause <span className="required">*</span>
-                    </label>
-                    <textarea
-                        className="textarea"
-                        name="aimAndCause"
-                        value={formData.aimAndCause}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                {error && <p className="error-message">{error}</p>}
-                {success && <p className="success-message">{success}</p>}
-                <div className="button-group">
-                    <button
-                        className="save-button"
-                        type="submit"
-                        disabled={isLoading}
-                    >
-                        Save
-                    </button>
-                    <button
-                        className="clear-button"
-                        type="button"
-                        disabled={isLoading}
-                        onClick={handleClear}
-                    >
-                        Clear
-                    </button>
-                </div>
-                <div className="back-to-programs">
-                    <Link to="/programs">
-                        <button className="back-button" disabled={isLoading}>
-                            Back to Programs
-                        </button>
-                    </Link>
-                </div>
-                {isLoading && <LoadingSpinner />}
-            </form>
+  return (
+    <div className="container">
+      <form
+        className="form"
+        onSubmit={e => {
+          e.preventDefault();
+          handleSave();
+        }}
+      >
+        <h1 className="heading">Add Program</h1>
+        <div className="form-group">
+          <label className="label">
+            Name <span className="required">*</span>
+          </label>
+          <input
+            className="input"
+            type="text"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            required
+          />
         </div>
-    );
+        <div className="form-group">
+          <label className="label">
+            Description <span className="required">*</span>
+          </label>
+          <textarea
+            className="textarea"
+            name="description"
+            value={formData.description}
+            onChange={handleChange}
+            required
+          />
+          {isTooLong(formData.description) && (
+            <p className="error-message">This field accepts a maximum of 500 characters.</p>
+          )}
+        </div>
+        <div className="form-group">
+          <label className="label">
+            Start Date <span className="required">*</span>
+          </label>
+          <input
+            className="input"
+            type="date"
+            name="startDate"
+            value={formData.startDate}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label className="label">
+            Aim and Cause <span className="required">*</span>
+          </label>
+          <textarea
+            className="textarea"
+            name="aimAndCause"
+            value={formData.aimAndCause}
+            onChange={handleChange}
+            required
+          />
+          {isTooLong(formData.aimAndCause) && (
+            <p className="error-message">This field accepts a maximum of 500 characters.</p>
+          )}
+        </div>
+        {error && <p className="error-message">{error}</p>}
+        {success && <p className="success-message">{success}</p>}
+        <div className="button-group">
+          <button
+            className="save-button"
+            type="submit"
+            disabled={isLoading || !isFormValid(formData)}
+          >
+            Save
+          </button>
+          <button
+            className="clear-button"
+            type="button"
+            disabled={isLoading}
+            onClick={handleClear}
+          >
+            Clear
+          </button>
+        </div>
+        <div className="back-to-programs">
+          <Link to="/programs">
+            <button className="back-button" disabled={isLoading}>
+              Back to Programs
+            </button>
+          </Link>
+        </div>
+        {isLoading && <LoadingSpinner />}
+      </form>
+    </div>
+  );
 };
 
 export default AddProgramPage;

--- a/client-app/src/Components/EditProgramPage.tsx
+++ b/client-app/src/Components/EditProgramPage.tsx
@@ -5,164 +5,173 @@ import axios from 'axios';
 import LoadingSpinner from './LoadingSpinner';
 
 interface ProgramData {
-    name: string;
-    description: string;
-    startDate: string;
-    aimAndCause: string;
+  name: string;
+  description: string;
+  startDate: string;
+  aimAndCause: string;
 }
 
+const MAX_TEXT = 500;
+const isTooLong = (s: string) => s.trim().length > MAX_TEXT;
+const isEmpty = (s: string) => s.trim().length === 0;
+const isFormValid = (d: ProgramData) =>
+  !isEmpty(d.name) &&
+  !isEmpty(d.startDate) &&
+  !isEmpty(d.description) &&
+  !isEmpty(d.aimAndCause) &&
+  !isTooLong(d.description) &&
+  !isTooLong(d.aimAndCause);
+
 const EditProgramPage = () => {
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null);
-    const [isLoading, setIsLoading] = useState(false);
-    const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
 
-    let program = null;
-    const programData = localStorage.getItem('program');
-    if (programData) {
-        program = JSON.parse(programData);
-    }
-    if (!program) {
-        console.error('Program does not exist!');
-        navigate('/programs');
-    }
-    const programId = program.id;
-    const [formData, setFormData] = useState<ProgramData>({
-        name: program.name,
-        description: program.description,
-        startDate: program.startDate.toString().split('T')[0],
-        aimAndCause: program.aimAndCause,
+  let program = null as any;
+  const programData = localStorage.getItem('program');
+  if (programData) {
+    program = JSON.parse(programData);
+  }
+  if (!program) {
+    navigate('/programs');
+  }
+  const programId = program?.id;
+  const [formData, setFormData] = useState<ProgramData>({
+    name: program?.name ?? '',
+    description: program?.description ?? '',
+    startDate: program?.startDate ? program.startDate.toString().split('T')[0] : '',
+    aimAndCause: program?.aimAndCause ?? '',
+  });
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value,
     });
+  };
 
-    const handleChange = (
-        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    ) => {
-        const { name, value } = e.target;
-        setFormData({
-            ...formData,
-            [name]: value,
-        });
-    };
+  const handleSave = async () => {
+    if (!isFormValid(formData)) return;
+    setIsLoading(true);
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_API_BASE_URL}program/edit`,
+        { ...formData, id: programId },
+      );
 
-    const handleSave = async () => {
-        setIsLoading(true);
-        try {
-            const response = await axios.post(
-                `${process.env.REACT_APP_BACKEND_API_BASE_URL}program/edit`,
-                { ...formData, id: programId },
-            );
+      if (response.status === 200) {
+        setSuccess('Program edited successfully! Returning...');
+        setError(null);
+        setTimeout(() => {
+          navigate('/programs');
+        }, 1200);
+      } else {
+        setError('Failed to edit program.');
+        setSuccess(null);
+      }
+    } catch (error: unknown) {
+      const message =
+        (error as any).response?.data?.message ||
+        'Error editing program';
+      setError(message);
+      setSuccess(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-            if (response.status === 200) {
-                setSuccess('Program edited successfully! Returning...');
-                setError(null);
-
-                setFormData({
-                    name: '',
-                    description: '',
-                    startDate: '',
-                    aimAndCause: '',
-                });
-
-                setTimeout(() => {
-                    navigate('/programs');
-                }, 2000);
-            } else {
-                setError('Failed to create program.');
-                setSuccess(null);
-            }
-        } catch (error: unknown) {
-            const message =
-                (error as any).response?.data?.message ||
-                'Error creating program';
-            setError(message);
-            setSuccess(null);
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    return (
-        <div className="container">
-            <form
-                className="form"
-                onSubmit={e => {
-                    e.preventDefault();
-                    handleSave();
-                }}
-            >
-                <h1 className="heading">Edit Program</h1>
-                <div className="form-group">
-                    <label className="label">
-                        Name <span className="required">*</span>
-                    </label>
-                    <input
-                        className="input"
-                        type="text"
-                        name="name"
-                        value={formData.name}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                <div className="form-group">
-                    <label className="label">
-                        Description <span className="required">*</span>
-                    </label>
-                    <textarea
-                        className="textarea"
-                        name="description"
-                        value={formData.description}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                <div className="form-group">
-                    <label className="label">
-                        Start Date <span className="required">*</span>
-                    </label>
-                    <input
-                        className="input"
-                        type="date"
-                        name="startDate"
-                        value={formData.startDate}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                <div className="form-group">
-                    <label className="label">
-                        Aim and Cause <span className="required">*</span>
-                    </label>
-                    <textarea
-                        className="textarea"
-                        name="aimAndCause"
-                        value={formData.aimAndCause}
-                        onChange={handleChange}
-                        required
-                    />
-                </div>
-                {error && <p className="error-message">{error}</p>}
-                {success && <p className="success-message">{success}</p>}
-                <div className="button-group">
-                    <button
-                        className="save-button"
-                        type="submit"
-                        disabled={isLoading}
-                    >
-                        Save
-                    </button>
-                </div>
-                <div className="back-to-programs">
-                    <Link to="/programs">
-                        <button className="back-button" disabled={isLoading}>
-                            Back to Programs
-                        </button>
-                    </Link>
-                </div>
-                {isLoading && <LoadingSpinner />}
-            </form>
+  return (
+    <div className="container">
+      <form
+        className="form"
+        onSubmit={e => {
+          e.preventDefault();
+          handleSave();
+        }}
+      >
+        <h1 className="heading">Edit Program</h1>
+        <div className="form-group">
+          <label className="label">
+            Name <span className="required">*</span>
+          </label>
+          <input
+            className="input"
+            type="text"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            required
+          />
         </div>
-    );
+        <div className="form-group">
+          <label className="label">
+            Description <span className="required">*</span>
+          </label>
+          <textarea
+            className="textarea"
+            name="description"
+            value={formData.description}
+            onChange={handleChange}
+            required
+          />
+          {isTooLong(formData.description) && (
+            <p className="error-message">This field accepts a maximum of 500 characters.</p>
+          )}
+        </div>
+        <div className="form-group">
+          <label className="label">
+            Start Date <span className="required">*</span>
+          </label>
+          <input
+            className="input"
+            type="date"
+            name="startDate"
+            value={formData.startDate}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label className="label">
+            Aim and Cause <span className="required">*</span>
+          </label>
+          <textarea
+            className="textarea"
+            name="aimAndCause"
+            value={formData.aimAndCause}
+            onChange={handleChange}
+            required
+          />
+          {isTooLong(formData.aimAndCause) && (
+            <p className="error-message">This field accepts a maximum of 500 characters.</p>
+          )}
+        </div>
+        {error && <p className="error-message">{error}</p>}
+        {success && <p className="success-message">{success}</p>}
+        <div className="button-group">
+          <button
+            className="save-button"
+            type="submit"
+            disabled={isLoading || !isFormValid(formData)}
+          >
+            Save
+          </button>
+        </div>
+        <div className="back-to-programs">
+          <Link to="/programs">
+            <button className="back-button" disabled={isLoading}>
+              Back to Programs
+            </button>
+          </Link>
+        </div>
+        {isLoading && <LoadingSpinner />}
+      </form>
+    </div>
+  );
 };
 
 export default EditProgramPage;


### PR DESCRIPTION
Fixes #199 

### What was changed?
- Added frontend validation to AddProgramPage.tsx and EditProgramPage.tsx for description and aimAndCause.
- Show inline error when > 500 chars: “This field accepts a maximum of 500 characters.”
- Disable Save until inputs are valid; submit handler blocks invalid requests.

### Why was it changed?

- Prevents generic backend errors and gives users clear guidance when fields exceed limits.

### How was it changed?
- Introduced helpers: MAX_TEXT=500, isTooLong, isEmpty, isFormValid.
- Render inline error under textareas when over limit.
- Save button disabled={!isFormValid(formData)} + early return in handleSave.

### Screenshots that show the changes :
<img width="1037" height="667" alt="image" src="https://github.com/user-attachments/assets/1cbca089-42a5-4aea-b03f-4ec3e87d381e" />

- **After:**
<img width="548" height="488" alt="image" src="https://github.com/user-attachments/assets/de56b8a2-6e87-4bab-81f7-c950f89c1354" />
<img width="1306" height="662" alt="edit" src="https://github.com/user-attachments/assets/be4c6b9b-58a7-4946-81fa-437b9b1b54c7" />

